### PR TITLE
Implement union (+) for Polygon

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "dn-m/Collections" "1.19"
+github "dn-m/Collections" "1.19.1"
 github "dn-m/ArithmeticTools" "0.13.4"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "dn-m/Collections" "1.18.7"
+github "dn-m/Collections" "1.18.8"
 github "dn-m/ArithmeticTools" "0.13.4"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "dn-m/Collections" "1.18.8"
+github "dn-m/Collections" "1.19"
 github "dn-m/ArithmeticTools" "0.13.4"

--- a/GeometryTools.xcodeproj/project.pbxproj
+++ b/GeometryTools.xcodeproj/project.pbxproj
@@ -370,7 +370,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0730;
-				LastUpgradeCheck = 0700;
+				LastUpgradeCheck = 0830;
 				TargetAttributes = {
 					09259D58553996BA6AE82A3B = {
 						LastSwiftMigration = 0830;
@@ -622,7 +622,7 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				CLANG_ENABLE_MODULES = YES;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEFINES_MODULE = YES;
@@ -742,7 +742,7 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				CLANG_ENABLE_MODULES = YES;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEFINES_MODULE = YES;

--- a/GeometryTools.xcodeproj/xcshareddata/xcschemes/GeometryTools iOS.xcscheme
+++ b/GeometryTools.xcodeproj/xcshareddata/xcschemes/GeometryTools iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0700"
+   LastUpgradeVersion = "0830"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/GeometryTools.xcodeproj/xcshareddata/xcschemes/GeometryTools macOS.xcscheme
+++ b/GeometryTools.xcodeproj/xcshareddata/xcschemes/GeometryTools macOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0700"
+   LastUpgradeVersion = "0830"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/GeometryTools/Line.swift
+++ b/GeometryTools/Line.swift
@@ -7,12 +7,13 @@
 //
 
 import Darwin
+import Collections
 import ArithmeticTools
 
 public struct Line {
     
     public var length: Double {
-        return sqrt(pow(end.x - start.x, 2) + pow(end.y - start.y, 2))
+        return vector.length
     }
     
     public var vector: Vector2 {
@@ -36,4 +37,36 @@ public struct Line {
         self.start = points[0]
         self.end = points[1]
     }
+    
+    public func y(x: Double) -> Double? {
+        
+        // Ensure line is positive
+        let (a,b,_) = ensuring(start, end) { start.x <= end.x }
+        
+        // Ensure x value is in domain
+        guard (a.x...b.x).contains(x) else {
+            return nil
+        }
+        
+        return x * (b.y - a.y) / (b.x - a.x) + a.y
+    }
+    
+    public func x(y: Double) -> Double? {
+        
+        // Ensure line is positive
+        let (a,b,_) = swapped(start,end) { start.y > end.y }
+        
+        // Ensure y value is in range of line
+        guard (a.y...b.y).contains(y) else {
+            return nil
+        }
+        
+        return (b.x - a.x) * (y - a.y) / (b.y - a.y) + a.x
+    }
+}
+
+/// - returns: If the given `predicate` is `true`, a tuple of `(b, a, true)`
+/// Otherwise, `(a, b, false)`
+public func ensuring <T> (_ a: T, _ b: T, that predicate: () -> Bool) -> (T, T, Bool) {
+    return predicate() ? (a, b, false) : (b, a, true)
 }

--- a/GeometryTools/Line.swift
+++ b/GeometryTools/Line.swift
@@ -10,34 +10,53 @@ import Darwin
 import Collections
 import ArithmeticTools
 
+/// Model of line.
 public struct Line {
     
-    public var length: Double {
-        return vector.length
-    }
+    // MARK: - Instance Properties
     
+    /// Vector of `Line`.
     public var vector: Vector2 {
         return Vector2(x: end.x - start.x, y: end.y - start.y)
     }
     
+    /// Length of `Line`.
+    public var length: Double {
+        return vector.length
+    }
+    
+    /// Start point.
     public let start: Point
+    
+    /// End point.
     public let end: Point
     
+    // MARK: - Initializers
+    
+    /// Creates a `Line` with the given `start` and `end` points.
     public init(start: Point, end: Point) {
         self.start = start
         self.end = end
     }
     
+    /// Create a `Line` with an array of `points`.
+    ///
+    /// - Warning: Will crash if given an array whose `count` is not two.
+    ///
     public init(points: [Point]) {
         
         guard points.count == 2 else {
-            fatalError("A triangle must have three vertices!")
+            fatalError("A line must have two vertices!")
         }
         
         self.start = points[0]
         self.end = points[1]
     }
     
+    // MARK: - Instance Methods
+    
+    /// - Returns: Vertical position for the given horizontal position, if it exists. 
+    /// Otherwise, `nil`.
     public func y(x: Double) -> Double? {
         
         // Ensure line is positive
@@ -50,7 +69,9 @@ public struct Line {
         
         return x * (b.y - a.y) / (b.x - a.x) + a.y
     }
-    
+ 
+    /// - Returns: Horizontal position for the given vertical position, if it exists.
+    /// Otherwise, `nil`.
     public func x(y: Double) -> Double? {
         
         // Ensure line is positive
@@ -65,8 +86,8 @@ public struct Line {
     }
 }
 
-/// - returns: If the given `predicate` is `true`, a tuple of `(b, a, true)`
+/// - returns: If the given `predicate` is `false`, a tuple of `(b, a, true)`
 /// Otherwise, `(a, b, false)`
-public func ensuring <T> (_ a: T, _ b: T, that predicate: () -> Bool) -> (T, T, Bool) {
+private func ensuring <T> (_ a: T, _ b: T, that predicate: () -> Bool) -> (T, T, Bool) {
     return predicate() ? (a, b, false) : (b, a, true)
 }

--- a/GeometryTools/Point.swift
+++ b/GeometryTools/Point.swift
@@ -50,6 +50,15 @@ extension Point: Equatable {
     }
 }
 
+extension Point: Hashable {
+    
+    // MARK: - Hashable
+    
+    public var hashValue: Int {
+        return "\(x)\(y)".hashValue
+    }
+}
+
 extension Point: CustomStringConvertible {
     
     // MARK: - CustomStringConvertible

--- a/GeometryTools/Polygon.swift
+++ b/GeometryTools/Polygon.swift
@@ -119,6 +119,19 @@ public struct Polygon: PolygonProtocol {
     }
 }
 
+extension Polygon: Monoid {
+    
+    /// Empty polygon.
+    public static let unit = Polygon(vertices: [])
+    
+    /// Creates union of two given `Polygon` values.
+    /// - Warning: Not yet implemented.
+    public static func + (lhs: Polygon, rhs: Polygon) -> Polygon {
+        fatalError("Not yet implemented!")
+        //return Polygon(vertices: lhs.vertices + rhs.vertices)
+    }
+}
+
 extension Polygon: Equatable {
     
     // MARK: Equatable

--- a/GeometryTools/Polygon.swift
+++ b/GeometryTools/Polygon.swift
@@ -78,7 +78,7 @@ public struct Polygon: PolygonProtocol {
         return clipEar(at: 0, from: counterClockwise.vertices, into: [])
     }
     
-    /// - Returns:
+    /// - Returns: Convex hull of vertices in `Polygon`.
     public var convexHull: Polygon {
         return Polygon(vertices: vertices.convexHull)
     }

--- a/GeometryTools/Polygon.swift
+++ b/GeometryTools/Polygon.swift
@@ -36,18 +36,8 @@ public struct Polygon: PolygonProtocol {
         /// - There are no remaining vertices contained within its area.
         ///
         func isEar(_ triangle: Triangle, remainingVertices: [Point]) -> Bool {
-            
-            // For the triangle to be an ear, it must be convex, given the order of traversal.
-            guard triangle.isConvex(rotation: .counterClockwise) else {
-                return false
-            }
-            
-            // For the triangle to be an ear, it must not have any remaining vertices within
-            // its area.
-            guard !triangle.contains(anyOf: remainingVertices) else {
-                return false
-            }
-            
+            guard triangle.isConvex(rotation: .counterClockwise) else { return false }
+            guard !triangle.contains(anyOf: remainingVertices) else { return false }
             return true
         }
         

--- a/GeometryTools/Polygon.swift
+++ b/GeometryTools/Polygon.swift
@@ -78,6 +78,11 @@ public struct Polygon: PolygonProtocol {
         return clipEar(at: 0, from: counterClockwise.vertices, into: [])
     }
     
+    /// - Returns:
+    public var convexHull: Polygon {
+        return Polygon(vertices: vertices.convexHull)
+    }
+    
     /// View of `Polygon` in which the vertices are ordered in a clockwise fashion.
     internal var clockwise: Polygon {
         return rotation == .clockwise ? self : Polygon(vertices: vertices.reversed())
@@ -117,8 +122,7 @@ extension Polygon: Monoid {
     /// Creates union of two given `Polygon` values.
     /// - Warning: Not yet implemented.
     public static func + (lhs: Polygon, rhs: Polygon) -> Polygon {
-        fatalError("Not yet implemented!")
-        //return Polygon(vertices: lhs.vertices + rhs.vertices)
+        return Polygon(vertices: (lhs.vertices + rhs.vertices).convexHull)
     }
 }
 

--- a/GeometryTools/PolygonProtocol.swift
+++ b/GeometryTools/PolygonProtocol.swift
@@ -63,7 +63,8 @@ extension PolygonProtocol {
     /// - Returns: `true` if a `PolygonProtocol` contains the given `point`.
     public func contains(_ point: Point) -> Bool {
         
-        ///
+        /// - Returns: The horizontal position of the intersection of horizontal ray shooting
+        /// from the given `point` through the given `edge`, if it exists. Otherwise, `nil`.
         func intersection(ofHorizontalRayFrom point: Point, through edge: Line) -> Double? {
             return edge.x(y: point.y)
         }

--- a/GeometryTools/Rectangle.swift
+++ b/GeometryTools/Rectangle.swift
@@ -132,7 +132,7 @@ public struct Rectangle: ConvexPolygonProtocol {
     
     /// - Returns: `true` if the given `point` is contained herein. Otherwise, `false`.
     public func contains(_ point: Point) -> Bool {
-        return (point.x >= minX && point.x <= maxX) && (point.y >= minY && point.y <= maxY)
+        return (minX...maxX).contains(point.x) && (minY...maxY).contains(point.y)
     }
 }
 

--- a/GeometryTools/Triangle.swift
+++ b/GeometryTools/Triangle.swift
@@ -12,15 +12,17 @@ import Collections
 /// Model of a triangle.
 public struct Triangle: ConvexPolygonProtocol {
     
+    /// Points comprising `Triangle`.
+    public var points: (p1: Point, center: Point, p2: Point) {
+        return (p1: vertices[0], center: vertices[1], p2: vertices[2])
+    }
+    
     // MARK: - Instance Properties
     
     /// - Returns: The angle of `Triangle`.
     public var angle: Angle {
         
-        let p1 = vertices[0]
-        let center = vertices[1]
-        let p2 = vertices[2]
-        
+        let (p1, center, p2) = points        
         let a = pow(center.x - p1.x, 2) + pow(center.y - p1.y, 2)
         let b = pow(center.x - p2.x, 2) + pow(center.y - p2.y, 2)
         let c = pow(p2.x - p1.x, 2) + pow(p2.y - p1.y, 2)
@@ -29,8 +31,7 @@ public struct Triangle: ConvexPolygonProtocol {
     }
     
     public var crossProduct: Double {
-        let (a,b,c) = (vertices[0], vertices[1], vertices[2])
-        return ((a.x * (c.y - b.y)) + (b.x * (a.y - c.y)) + (c.x * (b.y - a.y)))
+        return GeometryTools.crossProduct(vertices[0], vertices[1], vertices[2])
     }
     
     /// Vertices contained herein.
@@ -92,4 +93,8 @@ extension Triangle: Equatable {
     public static func == (lhs: Triangle, rhs: Triangle) -> Bool {
         return lhs.vertices == rhs.vertices
     }
+}
+
+internal func crossProduct(_ a: Point, _ b: Point, _ c: Point) -> Double {
+    return ((a.x * (c.y - b.y)) + (b.x * (a.y - c.y)) + (c.x * (b.y - a.y)))
 }

--- a/GeometryTools/Triangle.swift
+++ b/GeometryTools/Triangle.swift
@@ -60,10 +60,6 @@ public struct Triangle: ConvexPolygonProtocol {
 
     /// - Returns: `true` if `Triangle` is convex for the given `rotation`. Otherwise, `false`. 
     public func isConvex(rotation: Rotation) -> Bool {
-        
-        let (a,b,c) = (vertices[0], vertices[1], vertices[2])
-        let crossProduct = ((a.x * (c.y - b.y)) + (b.x * (a.y - c.y)) + (c.x * (b.y - a.y)))
-        
         switch rotation {
         case .counterClockwise:
             return crossProduct < 0 ? true : false

--- a/GeometryTools/Triangle.swift
+++ b/GeometryTools/Triangle.swift
@@ -28,6 +28,11 @@ public struct Triangle: ConvexPolygonProtocol {
         return Angle(radians: acos((a + b - c) / sqrt(4 * a * b)))
     }
     
+    public var crossProduct: Double {
+        let (a,b,c) = (vertices[0], vertices[1], vertices[2])
+        return ((a.x * (c.y - b.y)) + (b.x * (a.y - c.y)) + (c.x * (b.y - a.y)))
+    }
+    
     /// Vertices contained herein.
     public let vertices: VertexCollection
     
@@ -70,6 +75,7 @@ public struct Triangle: ConvexPolygonProtocol {
     /// - Returns: `true` if `Triangle` contains the given `point` in its area.
     public func contains(_ point: Point) -> Bool {
 
+        // zCrossProduct, then sign
         func sign(a: Point, b: Point, c: Point) -> FloatingPointSign {
             return ((a.x - c.x) * (b.y - c.y) - (b.x - c.x) * (a.y - c.y)).sign
         }

--- a/GeometryTools/Triangle.swift
+++ b/GeometryTools/Triangle.swift
@@ -22,7 +22,7 @@ public struct Triangle: ConvexPolygonProtocol {
     /// - Returns: The angle of `Triangle`.
     public var angle: Angle {
         
-        let (p1, center, p2) = points        
+        let (p1, center, p2) = points
         let a = pow(center.x - p1.x, 2) + pow(center.y - p1.y, 2)
         let b = pow(center.x - p2.x, 2) + pow(center.y - p2.y, 2)
         let c = pow(p2.x - p1.x, 2) + pow(p2.y - p1.y, 2)

--- a/GeometryTools/VertexCollection.swift
+++ b/GeometryTools/VertexCollection.swift
@@ -125,7 +125,3 @@ extension CircularArray where Element == Point {
         return sum > 0 ? .clockwise : .counterClockwise
     }
 }
-
-private func zCrossProduct(p1: Point, center: Point, p2: Point) -> Double {
-    return (p1.x - center.x) * (center.y - p2.y) - (p1.y - center.y) * (center.x - p2.x)
-}

--- a/GeometryTools/VertexCollection.swift
+++ b/GeometryTools/VertexCollection.swift
@@ -34,7 +34,7 @@ extension CircularArray where Element == Point {
                 guard
                     let penultimate = hull.penultimate,
                     let last = hull.last,
-                    !Triangle(penultimate, last, point).isConvex(rotation: .counterClockwise)
+                    crossProduct(penultimate, last, point) >= 0
                 else {
                     return hull + point
                 }
@@ -49,7 +49,7 @@ extension CircularArray where Element == Point {
             {
                 
                 // Base case: We have reached the end, and have succssfully populated the hull
-                guard index < vertices.count - 1 else {
+                guard index < vertices.count else {
                     return hull
                 }
                 

--- a/GeometryTools/VertexCollection.swift
+++ b/GeometryTools/VertexCollection.swift
@@ -43,7 +43,10 @@ extension CircularArray where Element == Point {
                 return dropVertices(from: Array(hull.dropLast()), point: point)
             }
             
-            //
+            // Adds the point at the given `index` of the given `vertices` to the given `hull`
+            // if, when added to the accumulating vertices in the `hull` creates a convex
+            // triangle. Otherwise, no point is added, and the vertex at the next index is 
+            // attempted.
             func addPoint(at index: Int, of vertices: VertexCollection, to hull: [Point])
                 -> [Point]
             {

--- a/GeometryTools/VertexCollection.swift
+++ b/GeometryTools/VertexCollection.swift
@@ -60,7 +60,7 @@ extension CircularArray where Element == Point {
             i -= 1
         }
 
-        return VertexCollection(lowerHull + upperHull.dropFirst())
+        return VertexCollection(lowerHull.dropLast() + upperHull.dropLast())
     }
     
     /// - returns: Array of the line values comprising the edges of the `PolygonProtocol`-

--- a/GeometryTools/VertexCollection.swift
+++ b/GeometryTools/VertexCollection.swift
@@ -15,6 +15,54 @@ public typealias VertexCollection = CircularArray<Point>
 /// - Note: One day, we will be able to say: `extension VertexCollection`.
 extension CircularArray where Element == Point {
     
+//    public func sorted(by areInIncreasingOrder: (Point, Point) -> Bool) -> CircularArray {
+//        // TODO: Inject this into `CircularArray` in `dn-m/Collections`
+//        return CircularArray(self.map { $0 }.sorted(by: areInIncreasingOrder))
+//    }
+    
+    /// - Note: Uses gift wrapping algorithm
+    public var convexHull: CircularArray {
+        
+        guard count > 3 else {
+            return self
+        }
+        
+        // TODO: Implement functional / recursive solution
+
+        // Sort vertices lexicographically (first by x, then by y in a tie)
+        let vertices = sorted { $0.x < $1.x || ($0.x == $1.x && $0.y < $1.y) }
+
+        var lowerHull: [Point] = []
+        for i in 0..<vertices.count {
+            while lowerHull.count >= 2 &&
+                zCrossProduct(
+                    p1: lowerHull[lowerHull.count - 2],
+                    center: lowerHull[lowerHull.count - 1],
+                    p2: vertices[i]) <= 0
+            {
+                _ = lowerHull.popLast()!
+            }
+            lowerHull.append(vertices[i])
+        }
+        
+        var upperHull: [Point] = []
+        var i = vertices.count - 1
+        while i >= 0 {
+            while upperHull.count >= 2 &&
+                zCrossProduct(
+                    p1: upperHull[upperHull.count - 2],
+                    center: upperHull[upperHull.count - 1],
+                    p2: vertices[i]) <= 0
+            {
+                _ = upperHull.popLast()!
+            }
+            upperHull.append(vertices[i])
+            i -= 1
+        }
+
+        return VertexCollection(lowerHull + upperHull.dropFirst())
+    }
+    
     /// - returns: Array of the line values comprising the edges of the `PolygonProtocol`-
     /// conforming type.
     public var edges: [Line] {

--- a/GeometryTools/VertexCollection.swift
+++ b/GeometryTools/VertexCollection.swift
@@ -124,14 +124,6 @@ extension CircularArray where Element == Point {
         }
         return sum > 0 ? .clockwise : .counterClockwise
     }
-    
-//    public func triangle(at index: Int) -> Triangle {
-//        return Triangle(
-//            self[circular: index - 1],
-//            self[circular: index],
-//            self[circular: index + 1]
-//        )
-//    }
 }
 
 private func zCrossProduct(p1: Point, center: Point, p2: Point) -> Double {

--- a/GeometryToolsTests/CollisionDetectionTests.swift
+++ b/GeometryToolsTests/CollisionDetectionTests.swift
@@ -78,4 +78,25 @@ class CollisionDetectionTests: XCTestCase {
         let blockC = Polygon(vertices: points)
         XCTAssertFalse(blockC.contains(Point(x: 0, y: 2)))
     }
+    
+    func testConvexHull() {
+        
+        let points = [
+            (1.5,0.5),
+            (1.5,1.5),
+            (1,2),
+            (0.5,1.5),
+            (0.5,0.5),
+            (1,0),
+            (2,0),
+            (2,1),
+            (2,2),
+            (0,2),
+            (0,1),
+            (0,0)
+        ].map(Point.init)
+        let vertices = VertexCollection(points)
+        let hull = vertices.convexHull
+        
+    }
 }

--- a/GeometryToolsTests/CollisionDetectionTests.swift
+++ b/GeometryToolsTests/CollisionDetectionTests.swift
@@ -100,6 +100,7 @@ class CollisionDetectionTests: XCTestCase {
         let hull = vertices.convexHull
         let expected = VertexCollection([(0,0),(2,0),(2,2),(0,2)].map(Point.init))
         
+        XCTAssertEqual(hull.count, expected.count)
         zip(hull, expected).forEach { a,b in XCTAssertEqual(a,b) }
     }
 }

--- a/GeometryToolsTests/CollisionDetectionTests.swift
+++ b/GeometryToolsTests/CollisionDetectionTests.swift
@@ -66,4 +66,16 @@ class CollisionDetectionTests: XCTestCase {
         
         XCTAssertEqual(expected, rect.xs(at: 75))
     }
+    
+    func testPolygonContainsPointTrue() {
+        let points = [(2,3),(0,3),(0,0),(2,0),(2,1),(1,1),(1,2),(2,2)].map(Point.init)
+        let blockC = Polygon(vertices: points)
+        XCTAssert(blockC.contains(Point(x: 0.5, y: 2.5)))
+    }
+    
+    func testPolygonContainsPointFalse() {
+        let points = [(2,3),(0,3),(0,0),(2,0),(2,1),(1,1),(1,2),(2,2)].map(Point.init)
+        let blockC = Polygon(vertices: points)
+        XCTAssertFalse(blockC.contains(Point(x: 0, y: 2)))
+    }
 }

--- a/GeometryToolsTests/CollisionDetectionTests.swift
+++ b/GeometryToolsTests/CollisionDetectionTests.swift
@@ -95,8 +95,11 @@ class CollisionDetectionTests: XCTestCase {
             (0,1),
             (0,0)
         ].map(Point.init)
+        
         let vertices = VertexCollection(points)
         let hull = vertices.convexHull
+        let expected = VertexCollection([(0,0),(2,0),(2,2),(0,2)].map(Point.init))
         
+        zip(hull, expected).forEach { a,b in XCTAssertEqual(a,b) }
     }
 }

--- a/GeometryToolsTests/PolygonTests.swift
+++ b/GeometryToolsTests/PolygonTests.swift
@@ -8,6 +8,7 @@
 
 import XCTest
 import Collections
+import ArithmeticTools
 @testable import GeometryTools
 
 class PolygonTests: XCTestCase {
@@ -142,5 +143,20 @@ class PolygonTests: XCTestCase {
         let b = Polygon(vertices: [(3,3),(5,3),(5,5),(3,5)].map(Point.init))
         let expected = Polygon(vertices: [(0,0),(2,0),(5,3),(5,5),(3,5),(0,2)].map(Point.init))
         XCTAssertEqual(a + b, expected)
+    }
+    
+    func testReduce() {
+        
+        let a = Polygon(vertices: [(0,0),(2,0),(2,2),(0,2)].map(Point.init))
+        let b = Polygon(vertices: [(3,3),(5,3),(5,5),(3,5)].map(Point.init))
+        let c = Polygon(vertices: [(0,6),(0,7),(-2,7),(-2,6)].map(Point.init))
+        
+        let expected = Polygon(
+            vertices: [(-2,6),(0,0),(2,0),(5,3),(5,5),(0,7),(-2,7)].map(Point.init)
+        )
+        
+        XCTAssertEqual(a + b + c, expected)
+        XCTAssertEqual([a,b,c].reduce(.unit, +), expected)
+        XCTAssertEqual([a,b,c].sum, expected)
     }
 }

--- a/GeometryToolsTests/PolygonTests.swift
+++ b/GeometryToolsTests/PolygonTests.swift
@@ -122,6 +122,7 @@ class PolygonTests: XCTestCase {
         let blockC = Polygon(vertices: points)
         let triangulated = blockC.triangulated
         XCTAssertEqual(triangulated.count, 6)
+        // FIXME: Add assertion!
     }
     
     func testBlockCTriangulatedClockwise() {
@@ -133,5 +134,13 @@ class PolygonTests: XCTestCase {
         let blockC = Polygon(vertices: points)
         let triangulated = blockC.triangulated
         XCTAssertEqual(triangulated.count, 6)
+        // FIXME: Add assertion!
+    }
+    
+    func testSum() {
+        let a = Polygon(vertices: [(0,0),(2,0),(2,2),(0,2)].map(Point.init))
+        let b = Polygon(vertices: [(3,3),(5,3),(5,5),(3,5)].map(Point.init))
+        let expected = Polygon(vertices: [(0,0),(2,0),(5,3),(5,5),(3,5),(0,2)].map(Point.init))
+        XCTAssertEqual(a + b, expected)
     }
 }


### PR DESCRIPTION
Implements the Gift Wrapping algorithm to find the convex hull of a set of vertices.

Enables:

```Swift
let a,b,c,d: Polygon
a + b // => Polygon
[a,b,c].reduce(.unit, +) // => Polygon
[a,b,c].sum // => Polygon
```