### PR TITLE
Implement Rectangle.scaledBy

### DIFF
--- a/GeometryTools/Rectangle.swift
+++ b/GeometryTools/Rectangle.swift
@@ -199,9 +199,9 @@ public struct Rectangle: ConvexPolygonProtocol {
         width widthScale: Double = 1,
         height heightScale: Double = 1,
         around anchor: ScaleAnchor
-        ) -> Rectangle
+    ) -> Rectangle
     {
-        let newSize = self.size.scaledBy(width: widthScale, height: heightScale)
+        let newSize = size.scaledBy(width: widthScale, height: heightScale)
 
         switch anchor {
         case .origin:

--- a/GeometryTools/Rectangle.swift
+++ b/GeometryTools/Rectangle.swift
@@ -202,6 +202,25 @@ public struct Rectangle: ConvexPolygonProtocol {
         }
     }
 
+    /// - Returns: `Rectangle` with dimensions scaled by the given `width` and `height`, around
+    /// the given `anchor`.
+    public func scaledBy(
+        width widthScale: Double = 1,
+        height heightScale: Double = 1,
+        around anchor: ScaleAnchor
+        ) -> Rectangle
+    {
+        let newSize = self.size.scaledBy(width: widthScale, height: heightScale)
+
+        switch anchor {
+        case .origin:
+            return Rectangle(origin: origin, size: newSize)
+        case .center:
+            let newOrigin = Point(x: center.x - newSize.width/2, y: center.y - newSize.height/2)
+            return Rectangle(origin: newOrigin, size: newSize)
+        }
+    }
+
 }
 
 extension Rectangle: Equatable {

--- a/GeometryTools/Rectangle.swift
+++ b/GeometryTools/Rectangle.swift
@@ -190,16 +190,7 @@ public struct Rectangle: ConvexPolygonProtocol {
     /// - Returns: `Rectangle` with dimensions scaled by the given `value` around the given
     /// `anchor`.
     public func scaled(by value: Double, around anchor: ScaleAnchor) -> Rectangle {
-        switch anchor {
-        case .origin:
-            return Rectangle(origin: origin, size: size.scaled(by: value))
-        case .center:
-            let size = self.size.scaled(by: value)
-            return Rectangle(
-                origin: Point(x: center.x - 0.5 * size.width, y: center.y + 0.5 * size.height),
-                size: size.scaled(by: value)
-            )
-        }
+        return scaledBy(width: value, height: value, around: anchor)
     }
 
     /// - Returns: `Rectangle` with dimensions scaled by the given `width` and `height`, around

--- a/GeometryToolsTests/RectangleTests.swift
+++ b/GeometryToolsTests/RectangleTests.swift
@@ -38,6 +38,20 @@ class RectangleTests: XCTestCase {
         XCTAssertEqual(r.normalized, expected)
     }
 
+    // MARK - scaled(by:, around:)
+
+    func testScaled() {
+        let r = Rectangle(origin: Point(x: 1, y: 5), size: Size(width: 2, height: 3))
+        let expected = Rectangle(origin: Point(x: 1, y: 5), size: Size(width: 6, height: 9))
+        XCTAssertEqual(r.scaled(by: 3, around: .origin), expected)
+    }
+
+    func testScaledAroundCenter() {
+        let r = Rectangle(origin: Point(x: 1, y: 5), size: Size(width: 2, height: 3))
+        let expected = Rectangle(origin: Point(x: -1, y: 2), size: Size(width: 6, height: 9))
+        XCTAssertEqual(r.scaled(by: 3, around: .center), expected)
+    }
+
     // MARK - scaledBy(width:, height:, around:)
 
     func testScaledBy() {

--- a/GeometryToolsTests/RectangleTests.swift
+++ b/GeometryToolsTests/RectangleTests.swift
@@ -12,6 +12,8 @@ import GeometryTools
 
 class RectangleTests: XCTestCase {
 
+    // MARK - normalized
+
     func testNormalizedIdentity() {
         let r = Rectangle(origin: Point(x: 0, y: 5), size: Size(width: 1, height: 2))
         let expected = r
@@ -34,6 +36,44 @@ class RectangleTests: XCTestCase {
         let r = Rectangle(origin: Point(x: 0, y: 5), size: Size(width: -1, height: -2))
         let expected = Rectangle(origin: Point(x: -1, y: 3), size: Size(width: 1, height: 2))
         XCTAssertEqual(r.normalized, expected)
+    }
+
+    // MARK - scaledBy(width:, height:, around:)
+
+    func testScaledBy() {
+        let r = Rectangle(origin: Point(x: 1, y: 5), size: Size(width: 2, height: 3))
+        let expected = Rectangle(origin: Point(x: 1, y: 5), size: Size(width: 6, height: 12))
+        XCTAssertEqual(r.scaledBy(width: 3, height: 4, around: .origin), expected)
+    }
+
+    func testScaledByWidthOnly() {
+        let r = Rectangle(origin: Point(x: 1, y: 5), size: Size(width: 2, height: 3))
+        let expected = Rectangle(origin: Point(x: 1, y: 5), size: Size(width: 6, height: 3))
+        XCTAssertEqual(r.scaledBy(width: 3, around: .origin), expected)
+    }
+
+    func testScaledByHeightOnly() {
+        let r = Rectangle(origin: Point(x: 1, y: 5), size: Size(width: 2, height: 3))
+        let expected = Rectangle(origin: Point(x: 1, y: 5), size: Size(width: 2, height: 9))
+        XCTAssertEqual(r.scaledBy(height: 3, around: .origin), expected)
+    }
+
+    func testScaledByAroundCenter() {
+        let r = Rectangle(origin: Point(x: 1, y: 5), size: Size(width: 2, height: 3))
+        let expected = Rectangle(origin: Point(x: -1, y: 0.5), size: Size(width: 6, height: 12))
+        XCTAssertEqual(r.scaledBy(width: 3, height: 4, around: .center), expected)
+    }
+
+    func testScaledByWidthOnlyAroundCenter() {
+        let r = Rectangle(origin: Point(x: 1, y: 5), size: Size(width: 2, height: 3))
+        let expected = Rectangle(origin: Point(x: -1, y: 5), size: Size(width: 6, height: 3))
+        XCTAssertEqual(r.scaledBy(width: 3, around: .center), expected)
+    }
+
+    func testScaledByHeightOnlyAroundCenter() {
+        let r = Rectangle(origin: Point(x: 1, y: 5), size: Size(width: 2, height: 3))
+        let expected = Rectangle(origin: Point(x: 1, y: 2), size: Size(width: 2, height: 9))
+        XCTAssertEqual(r.scaledBy(height: 3, around: .center), expected)
     }
 
 }


### PR DESCRIPTION
Fixes #42. Also implements scaled() in terms of scaledBy() and adds tests for both.